### PR TITLE
Fix 'yaml.load_all() without Loader=... is deprecated' warning

### DIFF
--- a/pippin/config.py
+++ b/pippin/config.py
@@ -38,7 +38,7 @@ class Config(object):
             cls._instance = cls.__new__(cls)
             try:
                 with open(f"{Utils.get_project_root().joinpath(pathlib.PurePath('config.yaml'))}", "r") as in_yaml:
-                    cls.yaml = list(yaml.load_all(in_yaml))[0]
+                    cls.yaml = list(yaml.load_all(in_yaml, Loader=yaml.FullLoader))[0]
             except FileNotFoundError:
                 cls.yaml = None
             # Parse options


### PR DESCRIPTION
## Problem

When starting `pippin-server` or on any `pippin-cli` execution there is an warning message:

```
.../Library/Python/3.7/lib/python/site-packages/pippin/config.py:41:
YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated,
as the default Loader is unsafe.
Please read https://msg.pyyaml.org/load for full details.
  cls.yaml = list(yaml.load_all(in_yaml))[0]
```
## Solution

According to the [documentation in the link](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation), provided by the error message above: 
> PyYAML's load function has been unsafe since the first release in May 2006...If you are the author/maintainer of the Python code that is triggering the warning, the best way to stop getting the warning is to specify the `Loader= argument` ....

Current PR is fixing the warning message by adding `Loader` argument to the `yaml.load_all()` call.