### PR TITLE
Handle WebSocket recv timeout on setup with error logging

### DIFF
--- a/pippin/network/nano_websocket.py
+++ b/pippin/network/nano_websocket.py
@@ -26,7 +26,11 @@ class WebsocketClient(object):
         try:
             self.ws = await websockets.connect(self.uri)
             await self.ws.send(json.dumps(subscription("confirmation", ack=True)))
-            await self.ws.recv()  # ack
+            await asyncio.wait_for(self.ws.recv(), 10)  # ack, timeout after waiting for 10 seconds
+        except asyncio.TimeoutError:
+            if not silent:
+                log.server_logger.critical("NANO WS: No response from connected websocket server. Ensure this server allows subscription to confirmations with no set filters")
+            raise
         except Exception as e:
             if not silent:
                 log.server_logger.critical("NANO WS: Error connecting to websocket server. Check your settings in ~/PippinData/config.yaml")


### PR DESCRIPTION
#19 
When a WebSocket is configured but does not send a message in response to the confirmation subscription message, the setup of the pippin-server hangs. This is what happens when the [Nano RPC Proxy](https://github.com/Joohansson/NanoRPCProxy) is used as the WebSocket server because it only allows subscription to confirmations when a set of accounts is set in options ([ref](https://docs.nano.org/integration-guides/websockets/#confirmations)). For the Nano RPC Proxy, this is [working as designed](https://github.com/Joohansson/NanoRPCProxy/issues/14). So I added a timeout to the WebSocket setup `recv` for 10 seconds with subsequent error logging.