### PR TITLE
Simple endpoint to receive payments

### DIFF
--- a/pippin/config.py
+++ b/pippin/config.py
@@ -72,7 +72,8 @@ class Config(object):
             # Go to default if None
             if cls.preconfigured_reps is None:
                 cls.preconfigured_reps = DEFAULT_BANANO_REPS if cls.banano else DEFAULT_NANO_REPS
-
+            cls.enable_payments = cls.get_yaml_property('payments', 'enabled', False)
+            cls.pingback_success_payment = cls.get_yaml_property('payments', 'pingback_success_payment', "http://localhost:8090")
         return cls._instance
 
     @classmethod

--- a/pippin/db/models/payment.py
+++ b/pippin/db/models/payment.py
@@ -1,0 +1,18 @@
+from tortoise.models import Model
+from tortoise import fields
+from enum import Enum, unique
+
+class Payment(Model):
+
+    def asdict(self):
+        return {'address': self.address, 'business_memo_id': self.business_memo_id, 'is_paid': self.is_paid}
+
+    id = fields.IntField(pk=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
+    address = fields.CharField(max_length=65, index=True, unique=True)
+    business_memo_id = fields.CharField(max_length=40)
+    is_paid = fields.BooleanField()
+    amount = fields.CharField(max_length=64) # in raw
+
+    class Meta:
+        table = 'payments'

--- a/pippin/db/tortoise_config.py
+++ b/pippin/db/tortoise_config.py
@@ -7,7 +7,7 @@ import pathlib
 class DBConfig(object):
     def __init__(self, mock = False):
         self.logger = logging.getLogger()
-        self.modules = {'db': ['pippin.db.models.wallet', 'pippin.db.models.account', 'pippin.db.models.adhoc_account', 'pippin.db.models.block']}
+        self.modules = {'db': ['pippin.db.models.wallet', 'pippin.db.models.account', 'pippin.db.models.adhoc_account', 'pippin.db.models.block', 'pippin.db.models.payment']}
         self.mock = mock
         if self.mock:
             self.use_postgres = False

--- a/pippin/network/rpc_client.py
+++ b/pippin/network/rpc_client.py
@@ -27,8 +27,8 @@ class RPCClient(object):
         if cls._instance is not None:
             cls._instance = None
 
-    async def make_request(self, req_json: dict):
-        async with self.session.post(self.node_url ,json=req_json, timeout=300) as resp:
+    async def make_request(self, req_json: dict, url = None):
+        async with self.session.post(self.node_url if url is None else url ,json=req_json, timeout=300) as resp:
             return await resp.json()
 
     async def account_balance(self, account: str) -> dict:

--- a/pippin/sample.config.yaml
+++ b/pippin/sample.config.yaml
@@ -76,3 +76,14 @@ wallet:
   # Maximum number of threads to sign blocks on.
   # Default: 1, minimum: 1
   #max_sign_threads: 1
+payments:
+  # `new_payment` action parameters are:
+  #   `amount` in raw 
+  #   `business_memo_id` from your app like `offerID-userID` as a string
+  #   `wallet` like other rpc calls
+  # Default: False
+  #enable_payments: false
+
+  # the url to pingback in case of successful payments
+  # Default: http://localhost:8090
+  #pingback_success_payment: http://localhost:8090


### PR DESCRIPTION
This PR add a new endpoint `new_payment`

It requires `wallet`, an `amount` in raw and a `business_memo_id` 
Each call to `new_payment` creates a new address/account. Not sure where is the implementation/discussion of block hand-off but for now this will do, at least for me (and probably for others)

Why this PR? It leverage pippin existing code. Code that would otherwise need to be written in each app and prone to errors.
It is a very simple system:
- receive a request from an app
- pippin replies with a new address generated for a payment
- within the block websocket callback, pippin verifies blocks if they are intended for a payment
- if a payment is fullfiled `amount_received >= amount_asked`  it sends a http ping to an url specified in the config

This PR is probably not within the scope of pippin but can be useful to others, it also start the discussion if it shall be implemented or not